### PR TITLE
ci: set up GitHub Actions to publish NPM package and API docs

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -40,7 +40,7 @@ jobs:
           LATEST_TAG=$(git tag -l --sort=-v:refname | head -n 1)
           echo "Latest tag is $LATEST_TAG"
           echo "Current tag is $GITHUB_REF_NAME"
-          if [ "${GITHUB_REF_NAME}" != "${LATEST_TAG}" ];
+          if [ "${GITHUB_REF_NAME}" != "${LATEST_TAG}" ]; then
             echo "Not the latest tag, skipping deploy."
             exit 0
           else

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,57 @@
+# This workflow will publish API docs to GitHub Pages when a new release tag is added to the main branch
+
+name: Publish API docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs
+
+      - name: Prepare tag
+        id: prepare_tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          LATEST_TAG=$(git tag -l --sort=-v:refname | head -n 1)
+          echo "Latest tag is $LATEST_TAG"
+          echo "Current tag is $GITHUB_REF_NAME"
+          if [ "${GITHUB_REF_NAME}" != "${LATEST_TAG}" ];
+            echo "Not the latest tag, skipping deploy."
+            exit 0
+          else
+            echo "This is the latest tag, proceeding with deploy."
+          fi
+          echo "DEPLOY_TAG_NAME=deploy-${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          tag_name: ${{ steps.prepare_tag.outputs.DEPLOY_TAG_NAME }}
+          tag_message: 'Deployment ${{ github.ref_name }}'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,29 @@
+# This workflow will publish a package to NPM registry when a release is published
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Publish to NPM on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository at the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - name: Publish the package to NPM
+        run: npm run publish:dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -25,7 +25,7 @@ if (fs.existsSync(distFolder)) {
 }
 
 // Install dependencies
-execSync('npm install', { stdio: 'inherit' });
+execSync('npm ci', { stdio: 'inherit' });
 
 // Build and pack
 execSync('npm run pack:dist', { stdio: 'inherit' });


### PR DESCRIPTION
**Description of changes:**
1. Set up GitHub Actions to publish the package to NPM registry when a release is published
2. Set up GitHub Actions to publish API docs to GitHub Pages when a new release tag is added to the main branch



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
