### PR TITLE
ci: update GitHub Actions to publish API docs on release or on manual trigger

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -3,24 +3,43 @@
 name: Publish API docs to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
+  release:
+    types:
+      - published
+  workflow_dispatch:
 
 jobs:
-  deploy:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+  check-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the latest release tag
+        id: fetch_latest_release_tag
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+          echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          echo "The latest release tag is $LATEST_TAG"
+
+      - name: Check release tag on release event
+        if: ${{ github.event_name == 'release' }}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          LATEST_TAG: ${{ steps.fetch_latest_release_tag.outputs.LATEST_TAG }}
+        run: |
+          if [[ "$RELEASE_TAG" != "$LATEST_TAG" ]]; then
+            echo "Release tag $RELEASE_TAG does not match the latest tag $LATEST_TAG."
+            exit 1
+          else
+            echo "Release tag $RELEASE_TAG matches the latest tag $LATEST_TAG."
+          fi
+
+  build:
+    needs: check-tag
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ steps.fetch_latest_release_tag.outputs.LATEST_TAG }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -33,25 +52,30 @@ jobs:
       - name: Build docs
         run: npm run docs
 
-      - name: Prepare tag
-        id: prepare_tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          LATEST_TAG=$(git tag -l --sort=-v:refname | head -n 1)
-          echo "Latest tag is $LATEST_TAG"
-          echo "Current tag is $GITHUB_REF_NAME"
-          if [ "${GITHUB_REF_NAME}" != "${LATEST_TAG}" ]; then
-            echo "Not the latest tag, skipping deploy."
-            exit 0
-          else
-            echo "This is the latest tag, proceeding with deploy."
-          fi
-          echo "DEPLOY_TAG_NAME=deploy-${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload static files as artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
-          tag_name: ${{ steps.prepare_tag.outputs.DEPLOY_TAG_NAME }}
-          tag_message: 'Deployment ${{ github.ref_name }}'
+          path: docs/
+
+  deploy:
+    needs: build
+
+    concurrency:
+      group: docs-publish
+      cancel-in-progress: true
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           ref: ${{ steps.fetch_latest_release_tag.outputs.LATEST_TAG }}
 
       - name: Set up Node.js

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
           ref: ${{ steps.fetch_latest_release_tag.outputs.LATEST_TAG }}
 
       - name: Set up Node.js


### PR DESCRIPTION
**Description of changes:**
- Update GitHub Actions `docs-publish.yml` to publish API docs on release or on manual trigger


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
