### PR TITLE
ci: add a GitHub workflow to run continuous integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Run continuous integration tests
+
+on: [push, pull_request, merge_group]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run unit tests
+        run: npm run test
+
+      - name: Test on generating docs
+        run: npm run docs

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,6 @@
 name: Run commitlint on git commit messages
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 jobs:
   commitlint:


### PR DESCRIPTION
*Description of changes:*
1. Add a GitHub workflow to run continuous integration tests on each pull request and merge event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
