### PR TITLE
ci: set the body-max-line-length rule in commitlint as a warning

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-        'body-max-line-length': [2, 'always', 140],
+        'body-max-line-length': [1, 'always', 140],
     },
 };


### PR DESCRIPTION
*Description of changes:*
- Dependabot commit messages body line lengths do not conform with commitlint's defaults. https://github.com/amzn/lib-3d-scene-viewer/actions/runs/16435404359/job/46444388214?pr=19
- This change sets the body-max-line-length rule in commitlint as a warning rather than an error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
